### PR TITLE
Making search results legible.

### DIFF
--- a/themes/HackTheBox.json
+++ b/themes/HackTheBox.json
@@ -28,7 +28,7 @@
 		"dropdown.listBackground": "#111927",
 		"editor.background": "#141d2b",
 		"editor.findMatchBackground": "#1a2332",
-		"editor.findMatchHighlightBackground": "#6e7b96",
+		"editor.findMatchHighlightBackground": "#6e7b968C",
 		"editor.findRangeHighlightBackground": "#6e7b96",
 		"editor.foldBackground": "#141d2b",
 		"editor.foreground": "#a4b1cd",


### PR DESCRIPTION
Hello @silofy and @barrosfilipe 

The search results were hard to read in the current version of hackthebox theme. As shown in the image below:
![image](https://user-images.githubusercontent.com/40709743/126029882-fbe64a70-032e-4e06-9963-acbc16db96e5.png)

I added opacity to the search highlight. So it doesn't disturb the color combinations of the theme but at the same time, it is readable too. 

![image](https://user-images.githubusercontent.com/40709743/126029896-0eb04998-0f62-4bc0-8c2f-0e76bffd5961.png?w=100)

Looking forward to seeing this change getting merged.
